### PR TITLE
Fix: fixed destroy controller

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -407,7 +407,9 @@ class Controller {
   destroy(resetScenes) {
     window.clearTimeout(this._refreshTimeout);
 
-    this._sceneObjects.forEach(scene => scene.destroy(resetScenes));
+    let sceneObjectsTmp = this._sceneObjects.map(scene => scene)
+
+    sceneObjectsTmp.forEach(scene => scene.destroy(resetScenes));
 
     this.options.container.removeEventListener('resize', this._onChange.bind(this), { passive: true });
     this.options.container.removeEventListener('scroll', this._onChange.bind(this), { passive: true });


### PR DESCRIPTION
add a map for _sceneObjects, because the scene calls the removeScene method and breaks forEach