### PR TITLE
hotfix: fixed triggerElement not throwing error

### DIFF
--- a/src/Scene.js
+++ b/src/Scene.js
@@ -96,7 +96,10 @@ class Scene {
         val = val || undefined;
         if (val) {
           const el = _.isString(val) ? Util.elements(val)[0] : val;
-          if (el && el.parentNode) {
+          if ( el === undefined ) {
+            console.error( `ERROR triggerElement: '${val}' is still undefined! Error not being thrown.`)
+          }
+          if (el !== undefined && el.parentNode) {
             val = el;
           } else {
             throw Error(`Element defined in option "triggerElement" was not found: ${val}`);


### PR DESCRIPTION
the truthy conditional "if (el && el.parentNode )" was validating true even if undefined. 